### PR TITLE
Add - Prevent Mass Pinging In Discord Channel When Multiple Products Are Refreshed (1.2.0)

### DIFF
--- a/example.config.json
+++ b/example.config.json
@@ -14,7 +14,8 @@
       "currency-symbol": "£",
       "enable-cart": true,
       "enable-buy-now": true,
-      "interval": 10000
+      "interval": 10000,
+      "mass-ping-limit": 10
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,8 @@
       "dependencies": {
         "cron-schedule": "^5.0.4",
         "deep-object-diff": "^1.1.9",
-        "discord-api-types": "^0.37.100",
-        "discord.js": "^14.16.2",
+        "discord-api-types": "^0.37.109",
+        "discord.js": "^14.16.3",
         "node-fetch": "^3.3.2"
       },
       "devDependencies": {
@@ -25,7 +25,7 @@
         "typescript": "^5.5.4"
       },
       "engines": {
-        "node": ">=20.17.0"
+        "node": ">=20.18.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -812,10 +812,11 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -877,15 +878,15 @@
       }
     },
     "node_modules/discord-api-types": {
-      "version": "0.37.100",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.100.tgz",
-      "integrity": "sha512-a8zvUI0GYYwDtScfRd/TtaNBDTXwP5DiDVX7K5OmE+DRT57gBqKnwtOC5Ol8z0mRW8KQfETIgiB8U0YZ9NXiCA==",
+      "version": "0.37.109",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.109.tgz",
+      "integrity": "sha512-B4W/ao8vempNVCS4/K4CeeCGhiabTcU7ekgqJy4/RytEsgkJP9hWS0MWZMcRP3wWzU/FXi6QqqvArZTJUfc6Iw==",
       "license": "MIT"
     },
     "node_modules/discord.js": {
-      "version": "14.16.2",
-      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.16.2.tgz",
-      "integrity": "sha512-VGNi9WE2dZIxYM8/r/iatQQ+3LT8STW4hhczJOwm+DBeHq66vsKDCk8trChNCB01sMO9crslYuEMeZl2d7r3xw==",
+      "version": "14.16.3",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.16.3.tgz",
+      "integrity": "sha512-EPCWE9OkA9DnFFNrO7Kl1WHHDYFXu3CNVFJg63bfU7hVtjZGyhShwZtSBImINQRWxWP2tgo2XI+QhdXx28r0aA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@discordjs/builders": "^1.9.0",
@@ -895,7 +896,7 @@
         "@discordjs/util": "^1.1.1",
         "@discordjs/ws": "1.1.1",
         "@sapphire/snowflake": "3.5.3",
-        "discord-api-types": "0.37.97",
+        "discord-api-types": "0.37.100",
         "fast-deep-equal": "3.1.3",
         "lodash.snakecase": "4.1.1",
         "tslib": "^2.6.3",
@@ -909,9 +910,9 @@
       }
     },
     "node_modules/discord.js/node_modules/discord-api-types": {
-      "version": "0.37.97",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.97.tgz",
-      "integrity": "sha512-No1BXPcVkyVD4ZVmbNgDKaBoqgeQ+FJpzZ8wqHkfmBnTZig1FcH3iPPersiK1TUIAzgClh2IvOuVUYfcWLQAOA==",
+      "version": "0.37.100",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.100.tgz",
+      "integrity": "sha512-a8zvUI0GYYwDtScfRd/TtaNBDTXwP5DiDVX7K5OmE+DRT57gBqKnwtOC5Ol8z0mRW8KQfETIgiB8U0YZ9NXiCA==",
       "license": "MIT"
     },
     "node_modules/doctrine": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "type": "module",
   "engines": {
-    "node": ">=20.17.0"
+    "node": ">=20.18.0"
   },
   "keywords": [
     "discord",
@@ -41,8 +41,8 @@
   "dependencies": {
     "cron-schedule": "^5.0.4",
     "deep-object-diff": "^1.1.9",
-    "discord-api-types": "^0.37.100",
-    "discord.js": "^14.16.2",
+    "discord-api-types": "^0.37.109",
+    "discord.js": "^14.16.3",
     "node-fetch": "^3.3.2"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ const stores = details.map(
             details['enable-cart'],
             details['enable-buy-now'],
             details['interval'],
+            details['mass-ping-limit'],
         ),
 );
 

--- a/src/interface/configInterface.ts
+++ b/src/interface/configInterface.ts
@@ -14,6 +14,7 @@ interface StoreDetails {
     'enable-cart': boolean;
     'enable-buy-now': boolean;
     interval: number;
+    'mass-ping-limit'?: number;
 }
 
 interface DiscordInformation {


### PR DESCRIPTION
**Version 1.2.0**

Feat:
- Allow stores to have a mass ping limit to group multiple refreshed products into one ping to prevent mass pinging
   - This is optional. To enable it, update your `config.js` file and set a value for `mass-ping-limit`
- Bump discord.js packages to latest supported version
- Bump Node.js required version to v21.18.0